### PR TITLE
CI: Fix import type declaration not found

### DIFF
--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "types": ["jest"]
+    "types": ["jest", "node"]
   }
 }


### PR DESCRIPTION
Although CI passes there is an error:
```
Failed to collect coverage from /home/runner/work/jupyter-fsspec/jupyter-fsspec/src/index.ts
ERROR: src/index.ts:1:23 - error TS2307: Cannot find module 'path' or its corresponding type declarations.

1 import * as path from 'path';
```
- Added resolution for node types