### PR TITLE
Sync project version and use dynamic version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterFsspec",
-    "version": "0.1.0",
+    "version": "0.3.0",
     "description": "A Jupyter interface for fsspec.",
     "keywords": [
         "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = ["hatchling>=1.5.0", "jupyterlab>=4.0.0,<5", "hatch-nodejs-version>=0
 build-backend = "hatchling.build"
 
 [project]
-version = "v0.3.0"
 name = "jupyter_fsspec"
 authors = [
     {name = "Jupyter Fsspec contributors"},
@@ -29,7 +28,7 @@ classifiers = [
 dependencies = [
     "fsspec"
 ]
-dynamic = ["description", "urls", "keywords"]
+dynamic = ["version", "description", "urls", "keywords"]
 
 [tool.hatch.version]
 source = "nodejs"


### PR DESCRIPTION
Currently:
- `Check Release / check_release` CI job is failing due to static version in toml file
- `package.json` and python package versions were out of sync

This PR:
- We can use the dynamic version and it is pulled into `package.json` with hatch (or manually modifying the `package.json`) and that dynamically resolves the python package version. as well. 