### PR TITLE
Self release workflows starting with TestPyPI

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,64 @@
+name: PyPI Publish Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_bump_version:
+        description: "Run bump-version?"
+        required: true
+        type: choice
+        options:
+          - "true"
+          - "false"
+        default: "true"
+      version:
+        description: "Enter the new version for the release e.g., 0.4.0"
+        required: true
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    environment: pypi-publish
+    permissions:
+      contents: write
+    if: github.ref == 'refs/heads/main' && github.event.inputs.run_bump_version == 'true'
+
+    steps:
+      - name: Call base bump version setup
+        uses: ./.github/workflows/setup-bump-version.yml
+        with:
+          version: "${{ github.event.inputs.version }}"
+
+      - name: Bump package version
+        run: |
+          hatch version ${{ github.event.inputs.version }}
+
+      - name: Commit and push version bump
+        run: |
+          git commit -am "Bump version to ${{ github.event.inputs.version }}" || (
+            echo "Error: No changes detected during version bump. Ensure the version is updated in the project files."
+            exit 1
+          )
+          git push || (
+            echo "Error: Failed to push changes. Check repo permissions."
+            exit 1
+          )
+
+      - name: Create and push tags
+        run: |
+          git tag -a "v${{ github.event.inputs.version }}" -m "Version ${github.event.inputs.version}"
+          git push origin "v${{ github.event.inputs.version }}"
+
+  release:
+    needs: [bump-version]
+    runs-on: ubuntu-latest
+    environment: pypi-publish
+    permissions:
+      id-token: write
+    if: github.ref == 'refs/heads/main' && (needs.bump-version.result == 'success' || needs.bump-version.result == null)
+
+    steps:
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy

--- a/.github/workflows/setup-bump-version.yml
+++ b/.github/workflows/setup-bump-version.yml
@@ -1,0 +1,32 @@
+name: Base Bump Version Setup
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+
+jobs:
+  setup-bump-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+        with:
+          extra-packages: build hatch
+
+      - name: Validate Version
+        run: |
+          if [[ ! "${{ inputs.version }}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))?([.-]?(a|b|rc)(0|[1-9][0-9]*))?$ ]]; then
+            echo "Invalid version format. Please use semantic versioning (e.g., 0.1.2 or 0.1.2a1)"
+            exit 1
+          fi
+
+      - name: Display version
+        run: |
+          echo "The entered version is: ${{ inputs.version }}"


### PR DESCRIPTION
Resolves #19
- Workflow to bump-release, commit version change, push tags
- Workflow to upload release to PyPI using a trusted publisher
- Currently pointed to TestPyPI