### PR TITLE
[Do Not Merge] Create memory root to avoid server error

### DIFF
--- a/jupyter_fsspec/file_manager.py
+++ b/jupyter_fsspec/file_manager.py
@@ -159,6 +159,11 @@ class FileSystemManager:
                 sync_fs = fsspec.filesystem(fs_protocol, *args, **kwargs)
                 fs = AsyncFileSystemWrapper(sync_fs)
 
+            # Temporary fix to handle memory filesystems with empty root path
+            if fs_protocol == "memory":
+                if not fs.exists(fs_path):
+                    fs.mkdir(fs_path)
+
             # Store the filesystem instance
             new_filesystems[key] = {
                 "instance": fs,

--- a/jupyter_fsspec/handlers.py
+++ b/jupyter_fsspec/handlers.py
@@ -296,10 +296,9 @@ class FileSystemHandler(APIHandler):
                     else fs_instance.cat_ranges([item_path], [int(start)], [int(end)])
                 )
 
-                for i in range(len(result)):
-                    if isinstance(result[i], bytes):
-                        result[i] = result[i].decode("utf-8")
-                response["content"] = result
+                response["content"] = [
+                    r.decode("utf-8") if isinstance(r, bytes) else r for r in result
+                ]
                 self.set_header("Content-Range", f"bytes {start}-{end}")
             elif isdir:
                 result = (

--- a/jupyter_fsspec/handlers.py
+++ b/jupyter_fsspec/handlers.py
@@ -281,22 +281,20 @@ class FileSystemHandler(APIHandler):
         is_async = fs_instance.async_impl
 
         try:
-            if is_async:
-                isdir = await fs_instance._isdir(item_path)
-            else:
-                isdir = fs_instance.isdir(item_path)
+            isdir = (
+                await fs_instance._isdir(item_path)
+                if is_async
+                else fs_instance.isdir(item_path)
+            )
 
             if get_request.type == "range":
                 range_header = self.request.headers.get("Range")
                 start, end = parse_range(range_header)
-                if is_async:
-                    result = await fs_instance._cat_ranges(
-                        [item_path], [int(start)], [int(end)]
-                    )
-                else:
-                    result = fs_instance.cat_ranges(
-                        [item_path], [int(start)], [int(end)]
-                    )
+                result = (
+                    await fs_instance._cat_ranges([item_path], [int(start)], [int(end)])
+                    if is_async
+                    else fs_instance.cat_ranges([item_path], [int(start)], [int(end)])
+                )
 
                 for i in range(len(result)):
                     if isinstance(result[i], bytes):
@@ -304,10 +302,11 @@ class FileSystemHandler(APIHandler):
                 response["content"] = result
                 self.set_header("Content-Range", f"bytes {start}-{end}")
             elif isdir:
-                if fs_instance.async_impl:
-                    result = await fs_instance._ls(item_path, detail=True)
-                else:
-                    result = fs_instance.ls(item_path, detail=True)
+                result = (
+                    await fs_instance._ls(item_path, detail=True)
+                    if is_async
+                    else fs_instance.ls(item_path, detail=True)
+                )
 
                 detail_to_keep = ["name", "type", "size", "ino", "mode"]
                 filtered_result = [
@@ -320,16 +319,14 @@ class FileSystemHandler(APIHandler):
                 ]
                 response["content"] = filtered_result
             else:
-                if fs_instance.async_impl:
-                    result = await fs_instance._cat(item_path)
-                    if isinstance(result, bytes):
-                        result = result.decode("utf-8")
-                    response["content"] = result
-                else:
-                    result = fs_instance.cat(item_path)
-                    if isinstance(result, bytes):
-                        result = result.decode("utf-8")
-                    response["content"] = result
+                result = (
+                    await fs_instance._cat(item_path)
+                    if is_async
+                    else fs_instance.cat(item_path)
+                )
+                response["content"] = (
+                    result.decode("utf-8") if isinstance(result, bytes) else result
+                )
             self.set_status(200)
             response["status"] = "success"
             response["description"] = f"Retrieved {item_path}."

--- a/jupyter_fsspec/tests/unit/test_filesystem_manager.py
+++ b/jupyter_fsspec/tests/unit/test_filesystem_manager.py
@@ -172,7 +172,8 @@ def test_check_reload_config(setup_config_dir, config_file):
 
         mem_fs_instance = mem_instance_info["instance"]
         assert mem_fs_instance.ls("/") == [
-            {"name": "/my_mem_dir", "size": 0, "type": "directory"}
+            {"name": "/my_mem_dir", "size": 0, "type": "directory"},
+            {"name": "/mem_dir", "size": 0, "type": "directory"},
         ]
 
 

--- a/jupyter_fsspec/tests/unit/test_filesystem_manager.py
+++ b/jupyter_fsspec/tests/unit/test_filesystem_manager.py
@@ -150,7 +150,8 @@ def test_load_populated_config(setup_config_dir, config_file):
 
         mem_fs_instance = mem_instance_info["instance"]
         assert mem_fs_instance.ls("/") == [
-            {"name": "/my_mem_dir", "size": 0, "type": "directory"}
+            {"name": "/my_mem_dir", "size": 0, "type": "directory"},
+            {"name": "/mem_dir", "size": 0, "type": "directory"},
         ]
 
 


### PR DESCRIPTION
Bringing back this block of code that creates the root path for a memory file system. Currently, the root path is not recognised as a directory after we instantiate a memory filesystem. Maybe there are better ways to address this? 
Follow-up from #86 and #87 