### PR TITLE
Update menu options for clarity

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,15 +28,47 @@ you select one of them, you will see a file browser (tree view) of those files b
 Basic navigation works as you'd expect: Click to expand/collapse folders, and right click for
 context options (such as copying the path of the current file to the clipboard).
 
-### Uploading files
+### Uploading Files
 
-You can pick files to upload from multiple source:
+Uploading files to your FSSpec filesystems allows you to:
 
-- From bytes inside your active notebook kernel
-  - `import` the `jupyter_fsspec.helper` module and designate bytes for upload with `jupyter_fsspec.helper.set_user_data(some_bytes)`, then right click the file path OR folder you want to upload to in Jupyter FSSpec and choose `Upload (helper.user_data)`
-- Browser/local file picker
-- JupyterLab's intergrated file browser
-  - Just right click one of the files in the integrated file browser and choose `Set as fsspec upload target`, then right click the file path OR folder you want to upload to in Jupyter FSSpec and choose `Upload to path (from integrated file browser)`
+- Transfer data between your local environment and remote storage systems
+- Share notebooks with datasets across different computing environments
+- Back up your work to cloud storage or other remote locations
+- Prepare data for distributed processing in cloud environments
+
+You can upload files from multiple sources:
+
+- **From bytes inside your active notebook kernel:**
+
+  - Import the `jupyter_fsspec.helper` module
+  - Designate bytes for upload with
+    `jupyter_fsspec.helper.set_user_data(some_bytes)`
+  - Right-click the target folder or location in Jupyter FSSpec
+  - Select `Upload from Helper Module`
+  - _Useful for: Programmatically generated data, processed results, or content
+    modified in your notebook_
+
+- **From your local computer:**
+
+  - Right-click the target folder or location in Jupyter FSSpec
+  - Select `Upload from Computer`
+  - Choose a file from the browser's file picker
+  - _Useful for: New datasets, configuration files, or results from external
+    tools_
+
+- **From JupyterLab's integrated file browser:**
+  - Right-click a file in JupyterLab's File Browser
+  - Select `Select as Upload Source for FSSpec`
+  - Right-click the target folder or location in Jupyter FSSpec
+  - Select `Upload from Jupyter File Browser`
+  - _Useful for: Moving files between your JupyterLab workspace and remote
+    storage systems_
+
+**Note:** To transfer files between different remote filesystems (e.g., from S3
+to GCS), you'll need to use the `helper` module in your notebook to download
+from one source and upload to another. Direct remote-to-remote transfers are not
+currently supported through the UI.
 
 ## Config File
 

--- a/src/FssFilesysContextMenu.ts
+++ b/src/FssFilesysContextMenu.ts
@@ -16,8 +16,12 @@ export class FssFilesysContextMenu {
     this.notebookTracker = notebookTracker;
 
     const actions = [
-      ['Copy Path', 'jfss-tree-context-item', 'copyPath'],
-      ['Copy `open` code block', 'jfss-tree-context-item', 'copyOpenCodeBlock'] // TODO: skip(?) if file path is directory
+      ['Copy Path to Clipboard', 'jfss-tree-context-item', 'copyPath'],
+      [
+        'Insert `open` Code Snippet',
+        'jfss-tree-context-item',
+        'copyOpenCodeBlock'
+      ] // TODO: skip(?) if file path is directory
     ];
     for (const action of actions) {
       this.createMenuItem(action[0], action[1], action[2]);

--- a/src/FssTreeItemContext.ts
+++ b/src/FssTreeItemContext.ts
@@ -23,24 +23,20 @@ export class FssTreeItemContext {
     this.parentControl = parentControl;
 
     const actions = [
-      ['Copy Path', 'jfss-tree-context-item', 'copyPath'],
-      ['Send Bytes to helper', 'jfss-tree-context-item', 'getBytes'],
+      ['Copy Path to Clipboard', 'jfss-tree-context-item', 'copyPath'],
+      ['Send to Helper Module', 'jfss-tree-context-item', 'getBytes'],
+      ['Upload from Helper Module', 'jfss-tree-context-item', 'uploadUserData'],
+      ['Upload from Computer', 'jfss-tree-context-item', 'uploadBrowserFile'],
       [
-        'Upload to path (helper.user_data)',
-        'jfss-tree-context-item',
-        'uploadUserData'
-      ],
-      [
-        'Upload to path (Browser file picker)',
-        'jfss-tree-context-item',
-        'uploadBrowserFile'
-      ],
-      [
-        'Upload to path (from integrated file browser)',
+        'Upload from Jupyter File Browser',
         'jfss-tree-context-item',
         'uploadJupyterBrowserFile'
       ],
-      ['Copy `open` code block', 'jfss-tree-context-item', 'copyOpenCodeBlock'] // TODO: skip(?) if file path is directory
+      [
+        'Insert `open` Code Snippet',
+        'jfss-tree-context-item',
+        'copyOpenCodeBlock'
+      ] // TODO: skip(?) if file path is directory
     ];
     for (const action of actions) {
       this.createMenuItem(action[0], action[1], action[2]);
@@ -115,7 +111,7 @@ export class FssTreeItemContext {
       const openCodeBlock = `with fsspec.open("${path}", "rt") as f:\n   for line in f:\n      print(line)`;
       navigator.clipboard.writeText(openCodeBlock).then(
         () => {
-          console.log('Copied `open` code block');
+          console.log('Inserted `open` code block');
           console.log(openCodeBlock);
           this.root.remove();
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1059,7 +1059,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
       // TODO verify filebrowserfactory and currentWidget are valid, file object is truthy etc.
       // Add Jupyter File Browser help
       app.commands.addCommand('jupyter_fsspec:filebrowser-context-upload', {
-        label: 'Set as fsspec upload target',
+        label: 'Select as Upload Source for FSSpec',
         caption:
           'Handles upload requests to configured fsspec filesystems from the FileBrowser',
         execute: async () => {

--- a/ui-tests/tests/filesystem_interaction.test.ts
+++ b/ui-tests/tests/filesystem_interaction.test.ts
@@ -199,8 +199,8 @@ test('test copy path', async ({ page }) => {
   await page.getByText('mydocs', { exact: true }).click({ button: 'right' });
 
   // Wait for pop up
-  await expect.soft(page.getByText('Copy Path')).toBeVisible();
-  await page.getByText('Copy Path').click();
+  await expect.soft(page.getByText('Copy Path to Clipboard')).toBeVisible();
+  await page.getByText('Copy Path to Clipboard').click();
 
   const copiedText = await page.evaluate(() => navigator.clipboard.readText());
   expect(copiedText).toEqual('memory:///mymemoryfs/mydocs');
@@ -263,7 +263,7 @@ test('test refresh for updated config', async ({ page }) => {
   expect(updatedFilesystemsCount).toEqual(2);
 });
 
-test('copy open with code block', async ({ page }) => {
+test('insert open code snippet', async ({ page }) => {
   // activate extension from launcher page
   await page.goto();
   await page.getByText('FSSpec', { exact: true }).click();
@@ -273,8 +273,8 @@ test('copy open with code block', async ({ page }) => {
     .getByText('myfile.txt', { exact: true })
     .click({ button: 'right' });
 
-  await expect.soft(page.getByText('Copy `open` code block')).toBeVisible();
-  await page.getByText('Copy `open` code block').click();
+  await expect.soft(page.getByText('Insert `open` Code Snippet')).toBeVisible();
+  await page.getByText('Insert `open` Code Snippet').click();
 
   const copiedText = await page.evaluate(() => navigator.clipboard.readText());
   expect(copiedText).toEqual(
@@ -282,7 +282,7 @@ test('copy open with code block', async ({ page }) => {
   );
 });
 
-test('copy open with code block with active notebook cell', async ({
+test('insert open with code snippet with active notebook cell', async ({
   page
 }) => {
   await page.goto();
@@ -303,9 +303,9 @@ test('copy open with code block with active notebook cell', async ({
     .getByText('myfile.txt', { exact: true })
     .click({ button: 'right' });
 
-  // click copy code block
-  await expect.soft(page.getByText('Copy `open` code block')).toBeVisible();
-  await page.getByText('Copy `open` code block').click();
+  // click insert code snippet
+  await expect.soft(page.getByText('Insert `open` Code Snippet')).toBeVisible();
+  await page.getByText('Insert `open` Code Snippet').click();
 
   // verify the clipboard contents
   const copiedText = await page.evaluate(() => navigator.clipboard.readText());
@@ -360,7 +360,7 @@ test('upload file from the Jupyterlab file browser', async ({ page }) => {
   await page.getByRole('listitem', { name: 'Name: Untitled.ipynb' }).click({
     button: 'right'
   });
-  await page.getByText('Set as fsspec upload target').click();
+  await page.getByText('Select as Upload Source for FSSpec').click();
 
   const file_locator = page
     .locator('jp-tree-view')
@@ -375,7 +375,7 @@ test('upload file from the Jupyterlab file browser', async ({ page }) => {
   );
 
   // Wait for pop up
-  const command = 'Upload to path (from integrated file browser)';
+  const command = 'Upload from Jupyter File Browser';
   await expect.soft(page.getByText(command)).toBeVisible();
   await page.getByText(command).highlight();
   await page.getByText(command).click();
@@ -452,7 +452,7 @@ test('upload file from browser picker', async ({ page }) => {
   const filePickerPromise = page.waitForEvent('filechooser');
 
   // Wait for pop up
-  const command = 'Upload to path (Browser file picker)';
+  const command = 'Upload from Computer';
   await expect.soft(page.getByText(command)).toBeVisible();
   await page.getByText(command).highlight();
   await page.getByText(command).click();
@@ -532,7 +532,7 @@ test('upload file from helper', async ({ page }) => {
   );
 
   // Wait for pop up
-  const command = 'Upload to path (helper.user_data)';
+  const command = 'Upload from Helper Module';
   await expect.soft(page.getByText(command)).toBeVisible();
   await page.getByText(command).highlight();
   await page.getByText(command).click();
@@ -559,7 +559,7 @@ test('upload file from helper', async ({ page }) => {
   expect.soft(jsonResponse).toEqual(response_body);
 });
 
-test('verify option `send bytes to helper` is present', async ({ page }) => {
+test('verify option `Send to Helper Module` is present', async ({ page }) => {
   page.on('console', logMsg => console.log('[BROWSER OUTPUT] ', logMsg.text()));
 
   await page.goto();
@@ -575,7 +575,7 @@ test('verify option `send bytes to helper` is present', async ({ page }) => {
   await file_locator.click({ button: 'right' });
 
   // Wait for pop up
-  const command = 'Send bytes to helper';
+  const command = 'Send to Helper Module';
   await expect.soft(page.getByText(command)).toBeVisible();
   await page.getByText(command).click();
 });


### PR DESCRIPTION
Fixes a portion of #119 and #118 but renaming the menu options:

FSSpec Menu Items:
- Copy Path -> Copy Path to Clipboard
- Send Bytes to helper -> Send to Helper Module
- Upload to path (helper.user_data) -> Upload from Helper Module
- Upload to path (Browser file picker) -> Upload from Computer
- Upload to path (from integrated file browser) -> Upload from Jupyter File Browser
- Copy `open` code block -> Insert `open` Code Snippet

Jupyterlab File Browser:
- Set as fsspec upload target -> Select as Upload Source for FSSpec

Updates docs to clarify more information about each option. A future PR could also add a tutorial or user guide.