### PR TITLE
Improve fsspec.open Code Snippet for Better Compatibility

### DIFF
--- a/src/FssFilesysContextMenu.ts
+++ b/src/FssFilesysContextMenu.ts
@@ -93,7 +93,7 @@ export class FssFilesysContextMenu {
     const path = this.copyPath();
 
     if (path) {
-      const openCodeBlock = `with fsspec.open("${path}", "rt") as f:\n   for line in f:\n      print(line)`;
+      const openCodeBlock = `with fsspec.open("${path}", "rb") as f:\n   print(f.readline())`;
       navigator.clipboard.writeText(openCodeBlock).then(
         () => {
           console.log('Copied `open` code block');

--- a/src/FssFilesysContextMenu.ts
+++ b/src/FssFilesysContextMenu.ts
@@ -93,7 +93,7 @@ export class FssFilesysContextMenu {
     const path = this.copyPath();
 
     if (path) {
-      const openCodeBlock = `with fsspec.open("${path}", "rb") as f:\n   print(f.readline())`;
+      const openCodeBlock = `with fsspec.open("${path}", "rb") as f:\n   ...`;
       navigator.clipboard.writeText(openCodeBlock).then(
         () => {
           console.log('Copied `open` code block');

--- a/src/FssTreeItemContext.ts
+++ b/src/FssTreeItemContext.ts
@@ -108,7 +108,7 @@ export class FssTreeItemContext {
     const path = this.copyPath();
 
     if (path) {
-      const openCodeBlock = `with fsspec.open("${path}", "rb") as f:\n   print(f.readline())`;
+      const openCodeBlock = `with fsspec.open("${path}", "rb") as f:\n   ...`;
       navigator.clipboard.writeText(openCodeBlock).then(
         () => {
           console.log('Inserted `open` code block');

--- a/src/FssTreeItemContext.ts
+++ b/src/FssTreeItemContext.ts
@@ -108,7 +108,7 @@ export class FssTreeItemContext {
     const path = this.copyPath();
 
     if (path) {
-      const openCodeBlock = `with fsspec.open("${path}", "rt") as f:\n   for line in f:\n      print(line)`;
+      const openCodeBlock = `with fsspec.open("${path}", "rb") as f:\n   print(f.readline())`;
       navigator.clipboard.writeText(openCodeBlock).then(
         () => {
           console.log('Inserted `open` code block');

--- a/ui-tests/tests/filesystem_interaction.test.ts
+++ b/ui-tests/tests/filesystem_interaction.test.ts
@@ -278,7 +278,7 @@ test('insert open code snippet', async ({ page }) => {
 
   const copiedText = await page.evaluate(() => navigator.clipboard.readText());
   expect(copiedText).toEqual(
-    `with fsspec.open("memory:///mymemoryfs/myfile.txt", "rb") as f:\n   print(f.readline())`
+    `with fsspec.open("memory:///mymemoryfs/myfile.txt", "rb") as f:\n   ...`
   );
 });
 
@@ -297,7 +297,7 @@ test('insert open with code snippet with active notebook cell', async ({
   const cellText = '# This is a code cell.';
   await page.notebook.addCell('code', cellText);
 
-  const copyCodeBlock = `with fsspec.open("memory:///mymemoryfs/myfile.txt", "rb") as f:\n   print(f.readline())`;
+  const copyCodeBlock = `with fsspec.open("memory:///mymemoryfs/myfile.txt", "rb") as f:\n   ...`;
 
   await page
     .getByText('myfile.txt', { exact: true })

--- a/ui-tests/tests/filesystem_interaction.test.ts
+++ b/ui-tests/tests/filesystem_interaction.test.ts
@@ -278,7 +278,7 @@ test('insert open code snippet', async ({ page }) => {
 
   const copiedText = await page.evaluate(() => navigator.clipboard.readText());
   expect(copiedText).toEqual(
-    `with fsspec.open("memory:///mymemoryfs/myfile.txt", "rt") as f:\n   for line in f:\n      print(line)`
+    `with fsspec.open("memory:///mymemoryfs/myfile.txt", "rb") as f:\n   print(f.readline())`
   );
 });
 
@@ -297,7 +297,7 @@ test('insert open with code snippet with active notebook cell', async ({
   const cellText = '# This is a code cell.';
   await page.notebook.addCell('code', cellText);
 
-  const copyCodeBlock = `with fsspec.open("memory:///mymemoryfs/myfile.txt", "rt") as f:\n   for line in f:\n      print(line)`;
+  const copyCodeBlock = `with fsspec.open("memory:///mymemoryfs/myfile.txt", "rb") as f:\n   print(f.readline())`;
 
   await page
     .getByText('myfile.txt', { exact: true })

--- a/ui-tests/tests/filesystem_interaction.test.ts
+++ b/ui-tests/tests/filesystem_interaction.test.ts
@@ -333,7 +333,7 @@ test('upload file from the Jupyterlab file browser', async ({ page }) => {
     'http://localhost:8888/jupyter_fsspec/files?action=write&key=mymem';
   const response_body = {
     status: 'success',
-    desctiption: 'Uploaded file'
+    description: 'Uploaded file'
   };
 
   await page.route(request_url + '**', route => {
@@ -410,7 +410,7 @@ test('upload file from browser picker', async ({ page }) => {
     'http://localhost:8888/jupyter_fsspec/files?action=write&key=mymem';
   const response_body = {
     status: 'success',
-    desctiption: 'uploaded file'
+    description: 'uploaded file'
   };
 
   await page.route(request_url + '**', route => {
@@ -487,7 +487,7 @@ test('upload file from helper', async ({ page }) => {
     'http://localhost:8888/jupyter_fsspec/files/transfer?action=upload';
   const response_body = {
     status: 'success',
-    desctiption: 'Uploaded file'
+    description: 'Uploaded file'
   };
 
   await page.route(request_url + '**', route => {


### PR DESCRIPTION
Closes #115.

## Changes
Updates the Insert `open` Code Snippet to:
- Use binary mode (`"rb"`) instead of text mode (`"rt"`)
- Replace iteration with `...` (pass) to give a place for you to write your code without an error
- Fix typos with the response body for some of the neighboring tests

Before:
```python
with fsspec.open("file:///My/file/path/CHANGE_LOG.md", "rt") as f:
   for line in f:
      print(line)
```

After:
```python
with fsspec.open("file:///My/file/path/CHANGE_LOG.md", "rb") as f:
   ...
```

## Rationale
- Improved compatibility**: Binary mode works with both text and binary files
- Prevents errors: For-loop iteration over non-text files (like parquet) would fail
