### PR TITLE
Update code blocks using kwargs and real paths

### DIFF
--- a/jupyter_fsspec/handlers.py
+++ b/jupyter_fsspec/handlers.py
@@ -94,7 +94,7 @@ class FsspecConfigHandler(APIHandler):
                 "path": fs_info["name"],
                 "prefix_path": fs_info["path"],
                 "canonical_path": fs_info["canonical_path"],
-                "kwargs": fs_info["instance"].storage_options,
+                "kwargs": fs_info["kwargs"],
             }
             file_systems.append(instance)
 

--- a/src/FssTreeItemContext.ts
+++ b/src/FssTreeItemContext.ts
@@ -138,8 +138,14 @@ export class FssTreeItemContext {
       (fsInfo.prefix_path ? fsInfo.prefix_path + '/' : '') +
       relative_path;
 
+    let openCodeBlock = '';
+    if (kwargs) {
+      openCodeBlock = `import fsspec\nimport json\nfsspec_kwargs = json.loads(${JSON.stringify(JSON.stringify(kwargs))})\nwith fsspec.open("${real_path}", mode="rb", **fsspec_kwargs) as f:\n   ...`;
+    } else {
+      openCodeBlock = `import fsspec\nwith fsspec.open("${real_path}", mode="rb"q) as f:\n   ...`;
+    }
+
     if (path) {
-      const openCodeBlock = `import json\nfsspec_kwargs = json.loads(${JSON.stringify(JSON.stringify(kwargs))})\nwith fsspec.open("${real_path}", mode="rb", **fsspec_kwargs) as f:\n   ...`;
       navigator.clipboard.writeText(openCodeBlock).then(
         () => {
           this.logger.info('Code snippet copied and inserted', {

--- a/src/FssTreeItemContext.ts
+++ b/src/FssTreeItemContext.ts
@@ -129,9 +129,17 @@ export class FssTreeItemContext {
 
   copyOpenCodeBlock() {
     const path = this.copyPath();
+    const kwargs = this.model.getActiveFilesystemInfo().kwargs;
+    const [_, relative_path] = path.split(/\/(.+)/);
+    const fsInfo = this.model.getActiveFilesystemInfo();
+    const real_path =
+      fsInfo.protocol +
+      '://' +
+      (fsInfo.prefix_path ? fsInfo.prefix_path + '/' : '') +
+      relative_path;
 
     if (path) {
-      const openCodeBlock = `with fsspec.open("${path}", "rb") as f:\n   ...`;
+      const openCodeBlock = `import json\nfsspec_kwargs = json.loads(${JSON.stringify(JSON.stringify(kwargs))})\nwith fsspec.open("${real_path}", mode="rb", **fsspec_kwargs) as f:\n   ...`;
       navigator.clipboard.writeText(openCodeBlock).then(
         () => {
           this.logger.info('Code snippet copied and inserted', {

--- a/ui-tests/tests/filesystem_interaction.test.ts
+++ b/ui-tests/tests/filesystem_interaction.test.ts
@@ -278,7 +278,7 @@ test('insert open code snippet', async ({ page }) => {
     .getByText('myfile.txt', { exact: true })
     .click({ button: 'right' });
 
-  const copyCodeBlock = `import json\nfsspec_kwargs = json.loads("{}")\nwith fsspec.open("memory:///mymemoryfs/myfile.txt", mode="rb", **fsspec_kwargs) as f:\n   ...`;
+  const copyCodeBlock = `import fsspec\nimport json\nfsspec_kwargs = json.loads("{}")\nwith fsspec.open("memory:///mymemoryfs/myfile.txt", mode="rb", **fsspec_kwargs) as f:\n   ...`;
   await expect.soft(page.getByText('Insert `open` Code Snippet')).toBeVisible();
   await page.getByText('Insert `open` Code Snippet').click();
 

--- a/ui-tests/tests/filesystem_interaction.test.ts
+++ b/ui-tests/tests/filesystem_interaction.test.ts
@@ -300,7 +300,7 @@ test('insert open with code snippet with active notebook cell', async ({
   // add a cell with some content
   const cellText = '# This is a code cell.';
   await page.notebook.addCell('code', cellText);
-  const copyCodeBlock = `import json\nfsspec_kwargs = json.loads("{}")\nwith fsspec.open("memory:///mymemoryfs/myfile.txt", mode="rb", **fsspec_kwargs) as f:\n   ...`;
+  const copyCodeBlock = `import fsspec\nimport json\nfsspec_kwargs = json.loads("{}")\nwith fsspec.open("memory:///mymemoryfs/myfile.txt", mode="rb", **fsspec_kwargs) as f:\n   ...`;
   await page
     .getByText('myfile.txt', { exact: true })
     .click({ button: 'right' });


### PR DESCRIPTION
This PR updates the `with fsspec.open()` code block to receive the configured filesystem `kwargs` and updates the path to be the real filesystem path reconstructed with the protocol and prefix. The ui-tests are also updated with an additional check to ensure the code block generated has not produced an error.