### PR TITLE
Fix docs notes and warnings

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,8 +5,8 @@
 # from the environment for the first two.
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
-SOURCEDIR     = source
-BUILDDIR      = build
+SOURCEDIR     = .
+BUILDDIR      = _build
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,3 +24,7 @@ exclude_patterns = []
 
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
+
+myst_enable_extensions = [
+    "colon_fence",  # enables ::: blocks like :::note
+]

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,7 +65,7 @@ You can upload files from multiple sources:
   - _Useful for: Moving files between your JupyterLab workspace and remote
     storage systems_
 
-:::note
+:::{note}
 **Note:** To transfer files between different remote filesystems (e.g., from S3
 to GCS), you'll need to use the `helper` module in your notebook to download
 from one source and upload to another. Direct remote-to-remote transfers are not
@@ -111,8 +111,8 @@ Lastly, you can pass additional arguments to the `fsspec` filesystem contructor 
 `args` and/or `kwargs` keys. You can check the `fsspec` docs for the available options that
 each filesystem implementation offers.
 
-:::warning
-**Warning:** By default, the file browser in jupyter_fsspec does not enforce Jupyter Server’s root
+:::{warning}
+By default, the file browser in jupyter_fsspec does not enforce Jupyter Server’s root
 directory restriction and will allow access to paths outside of it. To restrict access:
 
 - Set the CLI flag `--JupyterFsspec.allow_absolute_paths=False ` when instantiating the server
@@ -141,13 +141,13 @@ with fsspec.open('file://my/file/path', 'rb') as fhandle:
 filebytes[:256]
 ```
 
-:::note
-**Note:** In disctrubuted environments, (for e.g. remote kernels) the paths in the code
+:::{note}
+In disctrubuted environments, (for e.g. remote kernels) the paths in the code
 that the helper uses may not be valid unless the kernel and server share a filesystem.
 :::
 
-:::warning
-**Warning:** The environment variable "JUPYTER_FSSPEC_ALLOW_ABSOLUTE_PATHS" defaults to true, and
+:::{warning}
+The environment variable "JUPYTER_FSSPEC_ALLOW_ABSOLUTE_PATHS" defaults to true, and
 should be set to false in the kernel environment to ensure that the the helper does not
 instantiate filesystems with absolute paths.
 :::

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,7 @@ You can upload files from multiple sources:
     storage systems_
 
 :::{note}
-**Note:** To transfer files between different remote filesystems (e.g., from S3
+To transfer files between different remote filesystems (e.g., from S3
 to GCS), you'll need to use the `helper` module in your notebook to download
 from one source and upload to another. Direct remote-to-remote transfers are not
 currently supported through the UI.

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,10 +65,12 @@ You can upload files from multiple sources:
   - _Useful for: Moving files between your JupyterLab workspace and remote
     storage systems_
 
+:::note
 **Note:** To transfer files between different remote filesystems (e.g., from S3
 to GCS), you'll need to use the `helper` module in your notebook to download
 from one source and upload to another. Direct remote-to-remote transfers are not
 currently supported through the UI.
+:::
 
 ## Config File
 
@@ -109,8 +111,8 @@ Lastly, you can pass additional arguments to the `fsspec` filesystem contructor 
 `args` and/or `kwargs` keys. You can check the `fsspec` docs for the available options that
 each filesystem implementation offers.
 
-.. warning::
-By default, the file browser in jupyter_fsspec does not enforce Jupyter Server’s root
+:::warning
+**Warning:** By default, the file browser in jupyter_fsspec does not enforce Jupyter Server’s root
 directory restriction and will allow access to paths outside of it. To restrict access:
 
 - Set the CLI flag `--JupyterFsspec.allow_absolute_paths=False ` when instantiating the server
@@ -119,6 +121,7 @@ directory restriction and will allow access to paths outside of it. To restrict 
 This will ensure that `jupyter_fsspec` will only instantiate filesystems rooted within
 the server's working directory in both the browser UI and in the kernel side.
 Since the kernel is usually a fully privileged process, this restriction only applies to the automatic behavior of jupyter_fsspec.
+:::
 
 ## The `helper` module
 
@@ -138,14 +141,16 @@ with fsspec.open('file://my/file/path', 'rb') as fhandle:
 filebytes[:256]
 ```
 
-.. note::
-In disctrubuted environments, (for e.g. remote kernels) the paths in the code
+:::note
+**Note:** In disctrubuted environments, (for e.g. remote kernels) the paths in the code
 that the helper uses may not be valid unless the kernel and server share a filesystem.
+:::
 
-.. warning::
-The environment variable "JUPYTER_FSSPEC_ALLOW_ABSOLUTE_PATHS" defaults to true, and
+:::warning
+**Warning:** The environment variable "JUPYTER_FSSPEC_ALLOW_ABSOLUTE_PATHS" defaults to true, and
 should be set to false in the kernel environment to ensure that the the helper does not
 instantiate filesystems with absolute paths.
+:::
 
 <!--
 TODO populate this


### PR DESCRIPTION
This PR fixes the note and warning blocks in the documentation. 
It also corrects the make file source and build directory values so that `make html` works. 