### PR TITLE
Capture inactive filesystem error

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -90,6 +90,24 @@ def malformed_config(tmp_path: Path):
 
 
 @pytest.fixture(scope="function")
+def hdfs_config(tmp_path: Path):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(exist_ok=True)
+
+    yaml_content = """sources:
+  - name: "TestSourceHDF"
+    path: "hdfs://namenode.example.com:9000"
+    """
+    yaml_file = config_dir / "jupyter-fsspec.yaml"
+    yaml_file.write_text(yaml_content)
+
+    with patch(
+        "jupyter_fsspec.file_manager.jupyter_config_dir", return_value=str(config_dir)
+    ):
+        print(f"Patching jupyter_config_dir to: {config_dir}")
+
+
+@pytest.fixture(scope="function")
 def bad_info_config(tmp_path: Path):
     config_dir = tmp_path / "config"
     config_dir.mkdir(exist_ok=True)

--- a/jupyter_fsspec/handlers.py
+++ b/jupyter_fsspec/handlers.py
@@ -96,6 +96,8 @@ class FsspecConfigHandler(APIHandler):
                 "canonical_path": fs_info["canonical_path"],
                 "kwargs": fs_info["kwargs"],
             }
+            if fs_info.get("error", None):
+                instance["error"] = fs_info["error"]
             file_systems.append(instance)
 
         self.set_status(200)

--- a/jupyter_fsspec/tests/test_api.py
+++ b/jupyter_fsspec/tests/test_api.py
@@ -424,6 +424,22 @@ async def xtest_action_same_fs_files(fs_manager_instance, jp_fetch):
     )
 
 
+@pytest.mark.no_setup_config_file_fs
+async def test_hdfs_config(hdfs_config, jp_fetch):
+    fetch_config = await jp_fetch("jupyter_fsspec", "config", method="GET")
+    assert fetch_config.code == 200
+    config_json = fetch_config.body.decode("utf-8")
+    config = json.loads(config_json)
+    content = config["content"]
+    assert len(content) == 1
+    item = content[0]
+    assert item["error"]
+    assert (
+        item["error"]["short_traceback"]
+        == "ModuleNotFoundError: No module named 'pyarrow'"
+    )
+
+
 async def test_upload_download(fs_manager_instance, jp_fetch):
     fs_manager = await fs_manager_instance
     remote_key = "TestSourceAWS"

--- a/src/FssFilesysItem.ts
+++ b/src/FssFilesysItem.ts
@@ -190,7 +190,11 @@ class FssFilesysItem {
       protocol: this.filesysProtocol,
       path: this.fsInfo.path
     });
-
+    if (this.fsInfo.error) {
+      this.logger.error('Inactive filesystem', {
+        ...this.fsInfo.error
+      });
+    }
     this.selected = true;
     this.filesysClicked.emit(this.fsInfo);
   }

--- a/src/FssFilesysItem.ts
+++ b/src/FssFilesysItem.ts
@@ -36,6 +36,10 @@ class FssFilesysItem {
 
     const fsItem = document.createElement('div');
     fsItem.classList.add('jfss-fsitem-root');
+
+    if ('error' in fsInfo) {
+      fsItem.classList.add('jfss-fsitem-error');
+    }
     fsItem.addEventListener('mouseenter', this.handleFsysHover.bind(this));
     fsItem.addEventListener('mouseleave', this.handleFsysHover.bind(this));
     fsItem.dataset.fssname = fsInfo.name;

--- a/style/base.css
+++ b/style/base.css
@@ -159,6 +159,10 @@
   background-color: var(--jp-layout-color2);
 }
 
+.jfss-fsitem-error {
+  color: darkgrey;
+}
+
 .jfss-browseAreaLabel {
   width: 100%;
   margin: 0 0.5rem 0.5rem 0;


### PR DESCRIPTION
This PR addresses #138 
- [x] include the error message in the filesystem information object
- [x] a visual indicator that the filesystem is not properly initialized
- [x] log the error in the console
- [x] add tests to catch this error

TBD in a follow-up PRs:
- error message is displayed on hover
- sort filesystem items, those with an error initializing are displayed last
- add a setting to toggle whether the inactive filesystems should show up in the UI