### PR TITLE
Add MinIO quickstart example and update documentation structure

### DIFF
--- a/docs/examples/minio-quickstart.md
+++ b/docs/examples/minio-quickstart.md
@@ -1,0 +1,84 @@
+# Quickstart: S3‑compatible storage (MinIO, local)
+
+This example shows how to explore an S3‑compatible bucket with **Jupyter fsspec** using a local MinIO server.
+
+:::{note}
+This quickstart complements the **Config File** and **Basic Usage** sections. It assumes you already have JupyterLab installed and that you will run MinIO locally with Docker.
+:::
+
+---
+
+## Install required packages (one line)
+
+```bash
+pip install jupyter-fsspec s3fs
+```
+
+> If you already have JupyterLab, the command above just adds the fsspec extension and the S3 backend.
+
+---
+
+## Start MinIO locally (Docker)
+
+```bash
+# create a directory to store MinIO data
+mkdir -p ~/minio-data
+
+# run MinIO with S3 API on :9000 and Console on :9001
+# credentials are set to the defaults below for local testing only
+# (change them for anything beyond local dev)
+docker run -d --name minio \
+  -p 9000:9000 -p 9001:9001 \
+  -e MINIO_ROOT_USER=minioadmin \
+  -e MINIO_ROOT_PASSWORD=minioadmin \
+  -v ~/minio-data:/data \
+  minio/minio server /data --console-address ":9001"
+```
+
+- S3 API: `http://localhost:9000`
+- Web console: `http://localhost:9001` (login: `minioadmin / minioadmin`)
+
+Create a bucket in the console (e.g., **`test-bucket`**): **Buckets → Create bucket**.
+
+---
+
+## Configure the extension
+
+Create or edit `~/.jupyter/jupyter-fsspec.yaml` and add a source for your MinIO bucket. This example assumes you made a bucket called `test-bucket`.
+
+```yaml
+# ~/.jupyter/jupyter-fsspec.yaml
+sources:
+  - name: 'MinIO (local)'
+    path: 's3://test-bucket' # bucket you created
+    args: []
+    kwargs:
+      # authentication for MinIO
+      anon: false
+      key: 'minioadmin'
+      secret: 'minioadmin'
+
+      # point s3fs at your local MinIO endpoint
+      use_ssl: false
+      client_kwargs:
+        endpoint_url: 'http://127.0.0.1:9000'
+
+      # ensure path-style URLs (works best on localhost) and v4 signing
+      config_kwargs:
+        signature_version: 's3v4'
+        s3:
+          addressing_style: 'path'
+```
+
+:::{note}
+
+- `endpoint_url` directs `s3fs` to MinIO instead of AWS.
+- `addressing_style: path` avoids `bucket.localhost` hostnames by using path‑style URLs.
+- Keep `use_ssl: false` for local HTTP MinIO. If you terminate TLS, switch to `true` and use `https://` in `endpoint_url`.
+  :::
+
+---
+
+## Use it in JupyterLab
+
+Start JupyterLab. Open the **Jupyter fsspec** sidebar and select **"MinIO (local)"** to browse the bucket. Right‑click for actions such as copying the object path or uploading files (see **Uploading Files**).

--- a/docs/index.md
+++ b/docs/index.md
@@ -159,9 +159,12 @@ should be set to false in the kernel environment to ensure that the the helper d
 instantiate filesystems with absolute paths.
 :::
 
-<!--
-TODO populate this
+## Examples
+
+Practical examples demonstrating how to use Jupyter fsspec with different storage systems:
+
 ```{toctree}
-examples/content_child1.md
-examples/content_child2.md
-``` -->
+:maxdepth: 1
+
+examples/minio-quickstart.md
+```


### PR DESCRIPTION
## Overview

This PR adds a practical quickstart guide for testing the jupyter-fsspec extension with S3-compatible storage using a local MinIO server.

## Motivation

As a new user trying to understand and test this extension, I found that while the existing documentation excellently covers the configuration format and basic usage, there wasn't a complete end-to-end example I could follow without existing cloud credentials.

This led me to research how to set up a local S3-compatible environment for testing, which helped me:
- Understand how the extension works in practice
- Appreciate the value it brings to data science workflows  
- Successfully test all the key features (browsing, uploading, path copying)

## What This Adds

- **New Examples section** in the documentation structure
- **Complete MinIO quickstart guide** covering:
  - One-line installation (`pip install jupyter-fsspec s3fs`)
  - Local MinIO setup with Docker
  - Extension configuration for S3-compatible storage
  - Usage instructions in JupyterLab

## Why MinIO?

MinIO provides an ideal testing environment because it:
- Runs locally with Docker (no cloud accounts needed)
- Is fully S3-compatible 
- Allows new users to experience the extension's value immediately
- Demonstrates real-world S3 configuration patterns

## Design Decisions

- **Separate Examples section**: Creates a dedicated space for practical guides without disrupting existing documentation flow
- **Self-contained**: The guide includes everything needed from installation to usage
- **Beginner-friendly**: Assumes only JupyterLab installation and Docker availability

## Future Possibilities

This Examples section could serve as a foundation for similar quickstart guides covering other supported filesystems (GCS, Azure Blob Storage, SFTP, etc.), providing users with practical testing scenarios for various storage backends without requiring cloud accounts.

## Notes

I'm proposing this as a new contributor and want to be mindful of your documentation roadmap. If this doesn't align with your current plans or if you'd prefer a different approach, I'm happy to adapt or close this PR. My main goal is contributing something that might help other new users get started quickly.

## Testing

- Verified the documentation builds correctly
- Followed the guide end-to-end to ensure all steps work
- Tested all described functionality (browsing, uploading, context menu actions)